### PR TITLE
Création PermissionDTOFindAll

### DIFF
--- a/src/main/java/fr/associationrdj/backend/back/permission/PermissionController.java
+++ b/src/main/java/fr/associationrdj/backend/back/permission/PermissionController.java
@@ -1,5 +1,6 @@
 package fr.associationrdj.backend.back.permission;
 
+import fr.associationrdj.backend.back.permission.dto.PermissionDTOFindAll;
 import fr.associationrdj.backend.back.reservation.Reservation;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,7 +18,7 @@ public class PermissionController {
     }
 
     @GetMapping("")
-    public List<Permission> findAll(){
+    public List<PermissionDTOFindAll> findAll(){
         return permissionService.findAll();
     }
     @GetMapping("/{id}")

--- a/src/main/java/fr/associationrdj/backend/back/permission/PermissionService.java
+++ b/src/main/java/fr/associationrdj/backend/back/permission/PermissionService.java
@@ -1,6 +1,7 @@
 package fr.associationrdj.backend.back.permission;
 
-import fr.associationrdj.backend.back.commentaire.Commentaire;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.associationrdj.backend.back.permission.dto.PermissionDTOFindAll;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -10,14 +11,17 @@ import java.util.List;
 @Service
 public class PermissionService {
 
-    private PermissionRepository permissionRepository;
+    private final PermissionRepository permissionRepository;
+    private final ObjectMapper objectMapper;
 
-    public PermissionService(PermissionRepository permissionRepository) {
+    public PermissionService(PermissionRepository permissionRepository, ObjectMapper objectMapper) {
         this.permissionRepository = permissionRepository;
+        this.objectMapper = objectMapper;
     }
 
-    public List<Permission> findAll(){
-        return permissionRepository.findAll();
+    public List<PermissionDTOFindAll> findAll(){
+        List<Permission> permissions = permissionRepository.findAll();
+        return permissions.stream().map(permission -> objectMapper.convertValue(permission, PermissionDTOFindAll.class)).toList();
     }
 
     public Permission findById(Long id){

--- a/src/main/java/fr/associationrdj/backend/back/permission/dto/PermissionDTOFindAll.java
+++ b/src/main/java/fr/associationrdj/backend/back/permission/dto/PermissionDTOFindAll.java
@@ -1,0 +1,14 @@
+package fr.associationrdj.backend.back.permission.dto;
+
+import fr.associationrdj.backend.back.utilisateur.Utilisateur;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PermissionDTOFindAll {
+
+    private Long id;
+    private String statut;
+
+}


### PR DESCRIPTION
Création d'une DTO pour l'Entity Permission pour ne récupérer que le nom de la permission lors d'une méthode findAll():
- Création d'une classe PermissionDTOFindAll dans un package DTO.
- Modification de la méthode findAll() dans PermissionService.
- Modification du type de retour de la méthode findAll() dans PermissionController.